### PR TITLE
Scale per-key V component by global V component rather than ignoring per-key V component

### DIFF
--- a/app/src/rgb/keychron/per_key_rgb.c
+++ b/app/src/rgb/keychron/per_key_rgb.c
@@ -28,7 +28,7 @@ bool per_key_rgb_solid(effect_params_t *params) {
     RGB_MATRIX_USE_LIMITS(led_min, led_max);
     for (uint8_t i = led_min; i < led_max; i++) {
         HSV hsv = per_key_led[i];
-        hsv.v = rgb_matrix_config.hsv.v;
+        hsv.v   = scale8(rgb_matrix_config.hsv.v, hsv.v);
         RGB rgb = hsv_to_rgb(hsv);
         zmk_rgb_matrix_region_set_color(params->region, i, rgb.r, rgb.g, rgb.b);
     }
@@ -41,7 +41,8 @@ bool per_key_rgb_breahting(effect_params_t *params) {
 
     for (uint8_t i = led_min; i < led_max; i++) {
         HSV hsv = per_key_led[i];
-        hsv.v = scale8(abs8(sin8(time) - 128) * 2, rgb_matrix_config.hsv.v);
+        hsv.v   = scale8(rgb_matrix_config.hsv.v, hsv.v);
+        hsv.v   = scale8(abs8(sin8(time) - 128) * 2, hsv.v);
         RGB rgb = hsv_to_rgb(hsv);
         RGB_MATRIX_TEST_LED_FLAGS();
         zmk_rgb_matrix_region_set_color(params->region, i, rgb.r, rgb.g, rgb.b);
@@ -68,9 +69,8 @@ bool per_key_rgb_reactive_simple(effect_params_t *params) {
         uint16_t offset = scale16by8(tick, qadd8(rgb_matrix_config.speed, 1));
         HSV hsv = per_key_led[i];
 
-        hsv.v = scale8(255 - offset, rgb_matrix_config.hsv.v);
-        // if (per_key_led[i].v < hsv.v)
-        //     hsv.v = per_key_led[i].v;
+        hsv.v = scale8(rgb_matrix_config.hsv.v, hsv.v);
+        hsv.v = scale8(255 - offset, hsv.v);
 
         RGB rgb = hsv_to_rgb(hsv);
         zmk_rgb_matrix_region_set_color(params->region, i, rgb.r, rgb.g, rgb.b);
@@ -99,9 +99,8 @@ bool per_key_rgb_effect_runner_reactive_splash(uint8_t start, effect_params_t *p
         }
         hsv.h = per_key_led[i].h;
         hsv.s = per_key_led[i].s;
-        hsv.v = scale8(hsv.v, rgb_matrix_config.hsv.v);
-        // if (per_key_led[i].v < hsv.v)
-        //     hsv.v = per_key_led[i].v;
+        hsv.v = scale8(rgb_matrix_config.hsv.v, per_key_led[i].v);
+
         RGB rgb = hsv_to_rgb(hsv);
         zmk_rgb_matrix_region_set_color(params->region, i, rgb.r, rgb.g, rgb.b);
     }


### PR DESCRIPTION
See my equivalent qmk_firmware PR here: https://github.com/Keychron/qmk_firmware/pull/492

Applies the same changes on ZMK.  Tested on Keychron Q6 Ultra 8K.

Video of OpenRGB Effects Plugin with an effect that varies per-key brightness:

https://www.youtube.com/watch?v=vb103j4zNA8